### PR TITLE
ina281 rewrite for PIO

### DIFF
--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -3,9 +3,9 @@
 /*
     Initialize I2C bus member and parameters
 */
-INA281Driver::INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor)
+INA281Driver::INA281Driver(int analogPin, float resistance, float scaleFactor)
 {
-    this->pinAddr = pinAddr;
+    this->analogPin = analogPin;
     this->resistance = resistance;
     this->scaleFactor = scaleFactor; 
 }
@@ -17,7 +17,7 @@ float INA281Driver::readCurrent()
 {
     int valueRead;
 
-    valueRead = analogRead(pinAddr);
+    valueRead = analogRead(this->analogPin);
     
 
     float measuredVoltage = (float)valueRead * 5/1023;
@@ -35,7 +35,7 @@ float INA281Driver::readCurrent()
 float INA281Driver::readVoltage()
 {
     int valueRead;
-    valueRead = analogRead(pinAddr);
+    valueRead = analogRead(this->analogPin);
 
     float measuredVoltage = (float)valueRead * 5/1023;
 

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -3,13 +3,11 @@
 /*
     Initialize I2C bus member and parameters
 */
-INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, int Digital_Analog)
+INA281Driver::INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor)
 {
-    Wire.begin();
     this->pinAddr = pinAddr;
     this->resistance = resistance;
-    this->scaleFactor = scaleFactor;
-    this->Digital_Analog = Digital_Analog; 
+    this->scaleFactor = scaleFactor; 
 }
 
 /*
@@ -17,16 +15,12 @@ INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, in
 */
 float INA281Driver::readCurrent()
 {
-    float valueRead;
+    int valueRead;
 
-    if (Digital_Analog == 1){
-        valueRead = digitalRead(pinAddr);
-    }
-    else {
-        valueRead = analogRead(pinAddr);
-    }
+    valueRead = analogRead(pinAddr);
+    
 
-    float measuredVoltage = valueRead * 3.3;
+    float measuredVoltage = (float)valueRead * 5/1023;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -40,16 +34,12 @@ float INA281Driver::readCurrent()
 */
 float INA281Driver::readVoltage()
 {
-    float valueRead;
+    int valueRead;
+    valueRead = analogRead(pinAddr);
 
-    if (Digital_Analog == 1){
-        valueRead = digitalRead(pinAddr);
-    }
-    else {
-        valueRead = analogRead(pinAddr);
-    }
+    float measuredVoltage = (float)valueRead * 5/1023;
 
-    float voltage = valueRead / scaleFactor;
+    float voltage = measuredVoltage / scaleFactor;
 
     return voltage;
 }

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -20,7 +20,7 @@ float INA281Driver::readCurrent()
     valueRead = analogRead(this->analogPin);
     
 
-    float measuredVoltage = (float)valueRead * 5/1024;
+    float measuredVoltage = (float)valueRead * 3.3/1024.0;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -37,7 +37,7 @@ float INA281Driver::readVoltage()
     int valueRead;
     valueRead = analogRead(this->analogPin);
 
-    float measuredVoltage = (float)valueRead * 5/1024;
+    float measuredVoltage = (float)valueRead * 3.3/1024.0;
 
     float voltage = measuredVoltage / scaleFactor;
 

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -1,0 +1,55 @@
+#include "ina281.h"
+
+/*
+    Initialize I2C bus member and parameters
+*/
+INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, int Digital_Analog)
+{
+    Wire.begin();
+    this->pinAddr = pinAddr;
+    this->resistance = resistance;
+    this->scaleFactor = scaleFactor;
+    this->Digital_Analog = Digital_Analog; 
+}
+
+/*
+    Retrieve new current reading
+*/
+float INA281Driver::readCurrent()
+{
+    float valueRead;
+
+    if (Digital_Analog == 1){
+        valueRead = digitalRead(pinAddr);
+    }
+    else {
+        valueRead = analogRead(pinAddr);
+    }
+
+    float measuredVoltage = valueRead * 3.3;
+
+    // voltage = measuredVoltage / scaleFactor
+    // current = voltage / resistance
+    float current = (measuredVoltage / scaleFactor) / resistance;
+
+    return current;
+}
+
+/*
+    Retrieve new voltage reading
+*/
+float INA281Driver::readVoltage()
+{
+    float valueRead;
+
+    if (Digital_Analog == 1){
+        valueRead = digitalRead(pinAddr);
+    }
+    else {
+        valueRead = analogRead(pinAddr);
+    }
+
+    float voltage = valueRead / scaleFactor;
+
+    return voltage;
+}

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -34,8 +34,7 @@ float INA281Driver::readCurrent()
 */
 float INA281Driver::readVoltage()
 {
-    int valueRead;
-    valueRead = analogRead(this->analogPin);
+    int valueRead = analogRead(this->analogPin);
 
     float measuredVoltage = (float)valueRead * 3.3/1024.0;
 

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -20,7 +20,7 @@ float INA281Driver::readCurrent()
     valueRead = analogRead(this->analogPin);
     
 
-    float measuredVoltage = (float)valueRead * 5/1023;
+    float measuredVoltage = (float)valueRead * 5/1024;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -37,7 +37,7 @@ float INA281Driver::readVoltage()
     int valueRead;
     valueRead = analogRead(this->analogPin);
 
-    float measuredVoltage = (float)valueRead * 5/1023;
+    float measuredVoltage = (float)valueRead * 5/1024;
 
     float voltage = measuredVoltage / scaleFactor;
 

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -1,0 +1,45 @@
+#ifndef _INA281_H_
+#define _INA281_H_
+
+#include <Wire.h>
+
+/*
+    A class which represents an instance of an INA281 Driver for measuring current across a
+    shunt resistor. The analog output pin of the INA gives the voltage across the shunt resistor 
+    multiplied by a scale factor (default 20). Current is calculated from voltage and resistance 
+    using V = IR.
+*/
+class INA281Driver {
+ private:
+    uint8_t pinAddr;
+    float resistance;
+    float scaleFactor;
+    int Digital_Analog; //This was added because I did not know how to differentiate between digital and analog pins during the execution of the code.
+
+ public:
+
+   /*
+        Creates a new INA281 Driver
+
+        Constructor expects 2 arguments:
+        pinAddr - name of analog/digital pin the INA is wired to
+        resistance - resistance of the shunt resistor associated with the INA
+        Digital_Analog - 1 for digital, 0 for analog.
+
+        Optional argument:
+        scaleFactor - the factor by which to divide the pin reading to get the correct voltage
+    */
+    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20, int Digital_Analog);
+
+    /*
+        Retrieves the current current reading
+    */
+    float readCurrent();   
+
+    /*
+        Retrieves the current voltage reading
+    */
+    float readVoltage();
+};
+
+#endif

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -21,9 +21,8 @@ class INA281Driver {
         Creates a new INA281 Driver
 
         Constructor expects 2 arguments:
-        pinAddr - name of analog/digital pin the INA is wired to
+        analogPin - name of analog pin the INA is wired to
         resistance - resistance of the shunt resistor associated with the INA
-        Digital_Analog - 1 for digital, 0 for analog.
 
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -11,7 +11,7 @@
 */
 class INA281Driver {
  private:
-    uint8_t pinAddr;
+    int analogPin;
     float resistance;
     float scaleFactor;
 
@@ -28,7 +28,7 @@ class INA281Driver {
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage
     */
-    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20);
+    INA281Driver(int analogPin, float resistance, float scaleFactor = 20);
 
     /*
         Retrieves the current current reading

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -14,7 +14,6 @@ class INA281Driver {
     uint8_t pinAddr;
     float resistance;
     float scaleFactor;
-    int Digital_Analog; //This was added because I did not know how to differentiate between digital and analog pins during the execution of the code.
 
  public:
 
@@ -29,7 +28,7 @@ class INA281Driver {
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage
     */
-    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20, int Digital_Analog);
+    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20);
 
     /*
         Retrieves the current current reading


### PR DESCRIPTION
ina281.h:
1. Replaced #include "mbed.os" and #include "mutexless_analog.h" with #include <Wire.h>
2. Redefined "AnalogInMutexless iNAPin" as "int analogPin" because the analog pin is accessed with an int address
3. Made corresponding changes to the constructor.

ina281.cpp:
1. Initialised analogPin along with other variables as opposed to older version where iNAPin was initialised with priority - "(line 6)  : iNAPin(pinName)"
2. Voltage values are now read using analog.Read() function which returns an integer. 
3. The values are in a range of 0,1023 representing 0 to 5V. They converted to proper voltage units by multiplying the value returned from analog.Read() by 3.3V/1024 units ( = 0.0032mV/unit).