### PR TITLE
Fw 221/canmanager

### DIFF
--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -3,9 +3,14 @@
 
 void CANManager::readISR() {
     // TODO: read CAN message and enqueue data
+    CAN_message_t CAN_message;
+    this->canBus.read(CAN_message); 
+    
+    CAN_data toQueue= {CAN_message.id, *CAN_message.buf, CAN_message.len}; //Dereferencing CAN_message.buf to convert it to uint8_t from uint8_t*
+    this->messageQueue.push(toQueue);
 } 
 
-CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency, uint8_t rx) : canBus(canPort, pins), messageQueue() {
+CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency) : canBus(canPort, pins), messageQueue() {
     // Attach RX pin and handler function to interrupt
     attachInterrupt(digitalPinToInterrupt(rx), [this]() { this->readISR(); }, RISING || FALLING);   //attaches an interrupt to handler (readISR) using lambda function and calls it on rising or falling edge
     this->canBus.enableMBInterrupts();                                                              //enables mailbox interrupts
@@ -24,7 +29,7 @@ int CANManager::sendMessage(int messageID, void* data, int length, int timeout) 
     // TODO: use a Ticker to handle the timeout
     unsigned long start = millis();
     // TODO: make sure to runQueue in between attempts to send.
-    boolean retValue = false;
+    bool retValue = false;
     CAN_message_t CAN_message;
     CAN_message.id = messageID;
     CAN_message.len = length;

--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -5,27 +5,48 @@ void CANManager::readISR() {
     // TODO: read CAN message and enqueue data
 } 
 
-CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency) : canBus(canPort, pins), messageQueue() {
-    // TODO: attach RX pin and handler function to interrupt
-    
-    // TODO: begin canBus and set its frequency
+CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency, uint8_t rx) : canBus(canPort, pins), messageQueue() {
+    // Attach RX pin and handler function to interrupt
+    attachInterrupt(digitalPinToInterrupt(rx), [this]() { this->readISR(); }, RISING || FALLING);   //attaches an interrupt to handler (readISR) using lambda function and calls it on rising or falling edge
+    this->canBus.enableMBInterrupts();                                                              //enables mailbox interrupts
 
+    // Begin canBus and set its frequency
+    this->canBus.begin();
+    this->canBus.setBaudRate(frequency);
 }
 
 CANManager::~CANManager() {
-
+    //Clear interrupt handlers
+    this->canBus.disableMBInterrupts();
 }
 
 int CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
     // TODO: use a Ticker to handle the timeout
-
+    unsigned long start = millis();
     // TODO: make sure to runQueue in between attempts to send.
-    return 0;
+    boolean retValue = false;
+    CAN_message_t CAN_message;
+    CAN_message.id = messageID;
+    CAN_message.len = length;
+    for (int i = 0; i < length; i++) {
+        CAN_message.buf[i] = ((uint8_t*)data)[i];
+    }
+    while (!(retValue = this->canBus.write(CAN_message)) && millis() - start < timeout){
+        this->runQueue(1);
+    }
+    return retValue;
 }
 
 void CANManager::runQueue(int duration) {
     // TODO: use Ticker to handle the duration
+    unsigned long start = millis();
 
     // TODO: dequeue a CAN message, and call readHandler to deal with the CAN message accordingly
-
+    while (millis() - start < duration){
+        if (!this->messageQueue.empty()) {
+            CAN_data msg = this->messageQueue.front();
+            this->messageQueue.pop();
+            this->readHandler(msg);                 //virtual void readHandler needed in header maybe?
+        }
+    }   
 }

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -27,8 +27,9 @@ class CANManager {
          * canPort: choose from CAN1, CAN2, CAN3 (NOTE: see STM32_CAN library for more details)
          * pins: choose from DEF, ALT1, ALT2
          * frequency: Baud rate of can bus
+         * rx: digital pin number to attach interrupt to
          */
-        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency = DEFAULT_CAN_FREQ);
+        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency = DEFAULT_CAN_FREQ, uint8_t rx);
 
         // Destructor stopping manager and freeing resources
         ~CANManager();

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -29,7 +29,7 @@ class CANManager {
          * frequency: Baud rate of can bus
          * rx: digital pin number to attach interrupt to
          */
-        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency = DEFAULT_CAN_FREQ, uint8_t rx);
+        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency = DEFAULT_CAN_FREQ);
 
         // Destructor stopping manager and freeing resources
         ~CANManager();

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -3,9 +3,9 @@
 /*
     Initialize I2C bus member and parameters
 */
-INA281Driver::INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor)
+INA281Driver::INA281Driver(int analogPin, float resistance, float scaleFactor)
 {
-    this->pinAddr = pinAddr;
+    this->analogPin = analogPin;
     this->resistance = resistance;
     this->scaleFactor = scaleFactor; 
 }
@@ -17,7 +17,7 @@ float INA281Driver::readCurrent()
 {
     int valueRead;
 
-    valueRead = analogRead(pinAddr);
+    valueRead = analogRead(this->analogPin);
     
 
     float measuredVoltage = (float)valueRead * 5/1023;
@@ -35,7 +35,7 @@ float INA281Driver::readCurrent()
 float INA281Driver::readVoltage()
 {
     int valueRead;
-    valueRead = analogRead(pinAddr);
+    valueRead = analogRead(this->analogPin);
 
     float measuredVoltage = (float)valueRead * 5/1023;
 

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -3,13 +3,11 @@
 /*
     Initialize I2C bus member and parameters
 */
-INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, int Digital_Analog)
+INA281Driver::INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor)
 {
-    Wire.begin();
     this->pinAddr = pinAddr;
     this->resistance = resistance;
-    this->scaleFactor = scaleFactor;
-    this->Digital_Analog = Digital_Analog; 
+    this->scaleFactor = scaleFactor; 
 }
 
 /*
@@ -17,16 +15,12 @@ INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, in
 */
 float INA281Driver::readCurrent()
 {
-    float valueRead;
+    int valueRead;
 
-    if (Digital_Analog == 1){
-        valueRead = digitalRead(pinAddr);
-    }
-    else {
-        valueRead = analogRead(pinAddr);
-    }
+    valueRead = analogRead(pinAddr);
+    
 
-    float measuredVoltage = valueRead * 3.3;
+    float measuredVoltage = (float)valueRead * 5/1023;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -40,16 +34,12 @@ float INA281Driver::readCurrent()
 */
 float INA281Driver::readVoltage()
 {
-    float valueRead;
+    int valueRead;
+    valueRead = analogRead(pinAddr);
 
-    if (Digital_Analog == 1){
-        valueRead = digitalRead(pinAddr);
-    }
-    else {
-        valueRead = analogRead(pinAddr);
-    }
+    float measuredVoltage = (float)valueRead * 5/1023;
 
-    float voltage = valueRead / scaleFactor;
+    float voltage = measuredVoltage / scaleFactor;
 
     return voltage;
 }

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -20,7 +20,7 @@ float INA281Driver::readCurrent()
     valueRead = analogRead(this->analogPin);
     
 
-    float measuredVoltage = (float)valueRead * 5/1024;
+    float measuredVoltage = (float)valueRead * 3.3/1024.0;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -37,7 +37,7 @@ float INA281Driver::readVoltage()
     int valueRead;
     valueRead = analogRead(this->analogPin);
 
-    float measuredVoltage = (float)valueRead * 5/1024;
+    float measuredVoltage = (float)valueRead * 3.3/1024.0;
 
     float voltage = measuredVoltage / scaleFactor;
 

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -1,0 +1,55 @@
+#include "ina281.h"
+
+/*
+    Initialize I2C bus member and parameters
+*/
+INA281Driver::INA281Driver(uint8_t addr, float resistance, float scaleFactor, int Digital_Analog)
+{
+    Wire.begin();
+    this->pinAddr = pinAddr;
+    this->resistance = resistance;
+    this->scaleFactor = scaleFactor;
+    this->Digital_Analog = Digital_Analog; 
+}
+
+/*
+    Retrieve new current reading
+*/
+float INA281Driver::readCurrent()
+{
+    float valueRead;
+
+    if (Digital_Analog == 1){
+        valueRead = digitalRead(pinAddr);
+    }
+    else {
+        valueRead = analogRead(pinAddr);
+    }
+
+    float measuredVoltage = valueRead * 3.3;
+
+    // voltage = measuredVoltage / scaleFactor
+    // current = voltage / resistance
+    float current = (measuredVoltage / scaleFactor) / resistance;
+
+    return current;
+}
+
+/*
+    Retrieve new voltage reading
+*/
+float INA281Driver::readVoltage()
+{
+    float valueRead;
+
+    if (Digital_Analog == 1){
+        valueRead = digitalRead(pinAddr);
+    }
+    else {
+        valueRead = analogRead(pinAddr);
+    }
+
+    float voltage = valueRead / scaleFactor;
+
+    return voltage;
+}

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -20,7 +20,7 @@ float INA281Driver::readCurrent()
     valueRead = analogRead(this->analogPin);
     
 
-    float measuredVoltage = (float)valueRead * 5/1023;
+    float measuredVoltage = (float)valueRead * 5/1024;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -37,7 +37,7 @@ float INA281Driver::readVoltage()
     int valueRead;
     valueRead = analogRead(this->analogPin);
 
-    float measuredVoltage = (float)valueRead * 5/1023;
+    float measuredVoltage = (float)valueRead * 5/1024;
 
     float voltage = measuredVoltage / scaleFactor;
 

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -1,0 +1,45 @@
+#ifndef _INA281_H_
+#define _INA281_H_
+
+#include <Wire.h>
+
+/*
+    A class which represents an instance of an INA281 Driver for measuring current across a
+    shunt resistor. The analog output pin of the INA gives the voltage across the shunt resistor 
+    multiplied by a scale factor (default 20). Current is calculated from voltage and resistance 
+    using V = IR.
+*/
+class INA281Driver {
+ private:
+    uint8_t pinAddr;
+    float resistance;
+    float scaleFactor;
+    int Digital_Analog; //This was added because I did not know how to differentiate between digital and analog pins during the execution of the code.
+
+ public:
+
+   /*
+        Creates a new INA281 Driver
+
+        Constructor expects 2 arguments:
+        pinAddr - name of analog/digital pin the INA is wired to
+        resistance - resistance of the shunt resistor associated with the INA
+        Digital_Analog - 1 for digital, 0 for analog.
+
+        Optional argument:
+        scaleFactor - the factor by which to divide the pin reading to get the correct voltage
+    */
+    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20, int Digital_Analog);
+
+    /*
+        Retrieves the current current reading
+    */
+    float readCurrent();   
+
+    /*
+        Retrieves the current voltage reading
+    */
+    float readVoltage();
+};
+
+#endif

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -21,9 +21,8 @@ class INA281Driver {
         Creates a new INA281 Driver
 
         Constructor expects 2 arguments:
-        pinAddr - name of analog/digital pin the INA is wired to
+        analogPin - name of analog pin the INA is wired to
         resistance - resistance of the shunt resistor associated with the INA
-        Digital_Analog - 1 for digital, 0 for analog.
 
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -11,7 +11,7 @@
 */
 class INA281Driver {
  private:
-    uint8_t pinAddr;
+    int analogPin;
     float resistance;
     float scaleFactor;
 
@@ -28,7 +28,7 @@ class INA281Driver {
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage
     */
-    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20);
+    INA281Driver(int analogPin, float resistance, float scaleFactor = 20);
 
     /*
         Retrieves the current current reading

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -14,7 +14,6 @@ class INA281Driver {
     uint8_t pinAddr;
     float resistance;
     float scaleFactor;
-    int Digital_Analog; //This was added because I did not know how to differentiate between digital and analog pins during the execution of the code.
 
  public:
 
@@ -29,7 +28,7 @@ class INA281Driver {
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage
     */
-    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20, int Digital_Analog);
+    INA281Driver(uint8_t pinAddr, float resistance, float scaleFactor = 20);
 
     /*
         Retrieves the current current reading


### PR DESCRIPTION
canmanager.h:
1. Added an extra uint8_t parameter to directly send address of the RX pin since the pazi88/STM32_CAN does not seem to have a function to directly access pins.

canmanager.cpp:
1. Queue functions dependent on timers use millis() instead of Ticker.
2. Doubt - readISR is an interrupt statement and canBus.read() returns a true or false so can we use that to periodically call readISR or is it going to be called by a control module higher up in hierarchy.
3. Doubt - Should the disrupter empty the queue?
4. Doubt - Should I check if .read() returns true before enqueuing?