### PR TITLE
CANManager rewrite

### DIFF
--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -7,7 +7,7 @@ CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency) : can
 }
 
 bool CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
-    bool retValue = false;                  //return value of write function. False by default
+    bool retValue = false; // return value of write function. False by default
 
     // Create a CAN message that is going to be written
     CAN_message_t CAN_message;                
@@ -31,11 +31,12 @@ bool CANManager::sendMessage(int messageID, void* data, int length, int timeout)
 }
 
 void CANManager::runQueue(int duration) {
-    // Storing the time when the function is called
-    unsigned long start = millis();
     CAN_message_t msg; 
 
-    // dequeues messageQueue until the duration is reached
+    // Storing the time when the function is called
+    unsigned long start = millis();
+
+    // reads by dequeuing messages from Rx Ring buffer until the duration is reached
     while (millis() - start < duration){
         if (this->canBus.read(msg)) {
             this->readHandler(msg); //calls readHandler function to process the message              

--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -2,12 +2,14 @@
 
 
 void CANManager::readISR() {
-    // TODO: read CAN message and enqueue data
+    // Read CAN message and enqueue data
     CAN_message_t CAN_message;
-    this->canBus.read(CAN_message); 
+    bool check = this->canBus.read(CAN_message);  //returns true if message is read successfully
     
-    CAN_data toQueue= {CAN_message.id, *CAN_message.buf, CAN_message.len}; //Dereferencing CAN_message.buf to convert it to uint8_t from uint8_t*
-    this->messageQueue.push(toQueue);
+    if (check){
+        CAN_data toQueue= {CAN_message.id, *CAN_message.buf, CAN_message.len}; //Dereferencing CAN_message.buf to convert it to uint8_t from uint8_t*
+        this->messageQueue.push(toQueue);
+    }
 } 
 
 CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency) : canBus(canPort, pins), messageQueue() {
@@ -23,35 +25,47 @@ CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int freq
 CANManager::~CANManager() {
     //Clear interrupt handlers
     this->canBus.disableMBInterrupts();
+
+    //Empties queue
+    while (!this->messageQueue.empty()) {
+        this->messageQueue.pop();
+    }
 }
 
 int CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
-    // TODO: use a Ticker to handle the timeout
+    // Storing the time when the function is called
     unsigned long start = millis();
-    // TODO: make sure to runQueue in between attempts to send.
-    bool retValue = false;
-    CAN_message_t CAN_message;
+    
+    bool retValue = false;                  //return value of write function. False by default
+
+    // Create a CAN message that is going to be written
+    CAN_message_t CAN_message;                
     CAN_message.id = messageID;
     CAN_message.len = length;
+
+    // Copy the data to the buffer
     for (int i = 0; i < length; i++) {
         CAN_message.buf[i] = ((uint8_t*)data)[i];
     }
+
+    // Keep trying to write the message until it is successful or timeout
     while (!(retValue = this->canBus.write(CAN_message)) && millis() - start < timeout){
         this->runQueue(1);
     }
-    return retValue;
+
+    return retValue;  //returns true if message is written successfully
 }
 
 void CANManager::runQueue(int duration) {
-    // TODO: use Ticker to handle the duration
+    // Storing the time when the function is called
     unsigned long start = millis();
 
-    // TODO: dequeue a CAN message, and call readHandler to deal with the CAN message accordingly
+    // dequeues messageQueue until the duration is reached
     while (millis() - start < duration){
         if (!this->messageQueue.empty()) {
             CAN_data msg = this->messageQueue.front();
             this->messageQueue.pop();
-            this->readHandler(msg);                 //virtual void readHandler needed in header maybe?
+            this->readHandler(msg);    //calls readHandler function to process the message              
         }
     }   
 }

--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -4,10 +4,11 @@
 void CANManager::readISR() {
     // Read CAN message and enqueue data
     CAN_message_t CAN_message;
+
     bool check = this->canBus.read(CAN_message);  //returns true if message is read successfully
-    
+
     if (check){
-        CAN_data toQueue= {CAN_message.id, *CAN_message.buf, CAN_message.len}; //Dereferencing CAN_message.buf to convert it to uint8_t from uint8_t*
+        CAN_data toQueue= {CAN_message.id, CAN_message.buf, CAN_message.len};
         this->messageQueue.push(toQueue);
     }
 } 

--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -1,42 +1,12 @@
 #include "canmanager.h"
 
-
-void CANManager::readISR() {
-    // Read CAN message and enqueue data
-    CAN_message_t CAN_message;
-
-    bool check = this->canBus.read(CAN_message);  //returns true if message is read successfully
-
-    if (check){
-        CAN_data toQueue= {CAN_message.id, CAN_message.buf, CAN_message.len};
-        this->messageQueue.push(toQueue);
-    }
-} 
-
-CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency) : canBus(canPort, pins), messageQueue() {
-    // Attach RX pin and handler function to interrupt
-    attachInterrupt(digitalPinToInterrupt(rx), [this]() { this->readISR(); }, RISING || FALLING);   //attaches an interrupt to handler (readISR) using lambda function and calls it on rising or falling edge
-    this->canBus.enableMBInterrupts();                                                              //enables mailbox interrupts
-
+CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency) : canBus(canPort, pins) {                                                            
     // Begin canBus and set its frequency
     this->canBus.begin();
     this->canBus.setBaudRate(frequency);
 }
 
-CANManager::~CANManager() {
-    //Clear interrupt handlers
-    this->canBus.disableMBInterrupts();
-
-    //Empties queue
-    while (!this->messageQueue.empty()) {
-        this->messageQueue.pop();
-    }
-}
-
-int CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
-    // Storing the time when the function is called
-    unsigned long start = millis();
-    
+bool CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
     bool retValue = false;                  //return value of write function. False by default
 
     // Create a CAN message that is going to be written
@@ -49,6 +19,9 @@ int CANManager::sendMessage(int messageID, void* data, int length, int timeout) 
         CAN_message.buf[i] = ((uint8_t*)data)[i];
     }
 
+    // Storing the time right before we try sending
+    unsigned long start = millis();
+
     // Keep trying to write the message until it is successful or timeout
     while (!(retValue = this->canBus.write(CAN_message)) && millis() - start < timeout){
         this->runQueue(1);
@@ -60,13 +33,12 @@ int CANManager::sendMessage(int messageID, void* data, int length, int timeout) 
 void CANManager::runQueue(int duration) {
     // Storing the time when the function is called
     unsigned long start = millis();
+    CAN_message_t msg; 
 
     // dequeues messageQueue until the duration is reached
     while (millis() - start < duration){
-        if (!this->messageQueue.empty()) {
-            CAN_data msg = this->messageQueue.front();
-            this->messageQueue.pop();
-            this->readHandler(msg);    //calls readHandler function to process the message              
+        if (this->canBus.read(msg)) {
+            this->readHandler(msg); //calls readHandler function to process the message              
         }
     }   
 }

--- a/canmanager/canmanager.cpp
+++ b/canmanager/canmanager.cpp
@@ -3,29 +3,55 @@
 
 void CANManager::readISR() {
     // TODO: read CAN message and enqueue data
+    CAN_message_t CAN_message;
+    this->canBus.read(CAN_message); 
+    
+    CAN_data toQueue= {CAN_message.id, *CAN_message.buf, CAN_message.len}; //Dereferencing CAN_message.buf to convert it to uint8_t from uint8_t*
+    this->messageQueue.push(toQueue);
 } 
 
-CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency) : canBus(canPort, pins), messageQueue() {
-    // TODO: attach RX pin and handler function to interrupt
-    
-    // TODO: begin canBus and set its frequency
+CANManager::CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency) : canBus(canPort, pins), messageQueue() {
+    // Attach RX pin and handler function to interrupt
+    attachInterrupt(digitalPinToInterrupt(rx), [this]() { this->readISR(); }, RISING || FALLING);   //attaches an interrupt to handler (readISR) using lambda function and calls it on rising or falling edge
+    this->canBus.enableMBInterrupts();                                                              //enables mailbox interrupts
 
+    // Begin canBus and set its frequency
+    this->canBus.begin();
+    this->canBus.setBaudRate(frequency);
 }
 
 CANManager::~CANManager() {
-
+    //Clear interrupt handlers
+    this->canBus.disableMBInterrupts();
 }
 
 int CANManager::sendMessage(int messageID, void* data, int length, int timeout) {
     // TODO: use a Ticker to handle the timeout
-
+    unsigned long start = millis();
     // TODO: make sure to runQueue in between attempts to send.
-    return 0;
+    bool retValue = false;
+    CAN_message_t CAN_message;
+    CAN_message.id = messageID;
+    CAN_message.len = length;
+    for (int i = 0; i < length; i++) {
+        CAN_message.buf[i] = ((uint8_t*)data)[i];
+    }
+    while (!(retValue = this->canBus.write(CAN_message)) && millis() - start < timeout){
+        this->runQueue(1);
+    }
+    return retValue;
 }
 
 void CANManager::runQueue(int duration) {
     // TODO: use Ticker to handle the duration
+    unsigned long start = millis();
 
     // TODO: dequeue a CAN message, and call readHandler to deal with the CAN message accordingly
-
+    while (millis() - start < duration){
+        if (!this->messageQueue.empty()) {
+            CAN_data msg = this->messageQueue.front();
+            this->messageQueue.pop();
+            this->readHandler(msg);                 //virtual void readHandler needed in header maybe?
+        }
+    }   
 }

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -7,19 +7,9 @@
 
 #define DEFAULT_CAN_FREQ 250000     // Match Elcon charger
 
-typedef struct {
-    uint32_t id;
-    uint8_t* buf;  
-    uint8_t len;
-} CAN_data;
-
 class CANManager {
     private:
-        std::queue<CAN_data> messageQueue; // CAN messages we read
         STM32_CAN canBus;                  // object to interface with CAN
-        
-        // Interrupt Service Routine/Handler to read CAN message and put the data in a queue
-        void readISR(); 
 
     public:
         /* Constructor initializing bus and all manager functions
@@ -27,17 +17,13 @@ class CANManager {
          * canPort: choose from CAN1, CAN2, CAN3 (NOTE: see STM32_CAN library for more details)
          * pins: choose from DEF, ALT1, ALT2
          * frequency: Baud rate of can bus
-         * rx: digital pin number to attach interrupt to
          */
-        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency = DEFAULT_CAN_FREQ);
-
-        // Destructor stopping manager and freeing resources
-        ~CANManager();
+        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency = DEFAULT_CAN_FREQ);
 
         /* Reads input message and does any logic handling needed
          * Intended to be implemented by class extension per board
          */
-        virtual void readHandler(CAN_data msg) = 0;
+        virtual void readHandler(CAN_message_t msg) = 0;
 
         /* Send a message over CAN
          *
@@ -46,7 +32,7 @@ class CANManager {
          * length: Size of data in bytes
          * timeout: in milliseconds
          */ 
-        int sendMessage(int messageID, void* data, int length, int timeout = 10);
+        bool sendMessage(int messageID, void* data, int length, int timeout = 10);
 
         /* Processes CAN (read) messages stored in messageQueue for a set duration. 
          * THIS IS THE FUNCTION TO CALL FOR PROCESSING CAN READ MESSAGES

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -1,8 +1,6 @@
 #ifndef __CAN_MANAGER_H__
 #define __CAN_MANAGER_H__
 
-#include <memory> // need this for shared_ptr
-#include <queue>
 #include "STM32_CAN.h"
 
 #define DEFAULT_CAN_FREQ 250000     // Match Elcon charger

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -27,8 +27,9 @@ class CANManager {
          * canPort: choose from CAN1, CAN2, CAN3 (NOTE: see STM32_CAN library for more details)
          * pins: choose from DEF, ALT1, ALT2
          * frequency: Baud rate of can bus
+         * rx: digital pin number to attach interrupt to
          */
-        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, int frequency = DEFAULT_CAN_FREQ);
+        CANManager(CAN_TypeDef* canPort, CAN_PINS pins, uint8_t rx, int frequency = DEFAULT_CAN_FREQ);
 
         // Destructor stopping manager and freeing resources
         ~CANManager();

--- a/canmanager/canmanager.h
+++ b/canmanager/canmanager.h
@@ -9,7 +9,7 @@
 
 typedef struct {
     uint32_t id;
-    uint8_t buf[8];  
+    uint8_t* buf;  
     uint8_t len;
 } CAN_data;
 


### PR DESCRIPTION
canmanager.h:
1. Added an extra uint8_t parameter to directly send address of the RX pin since the pazi88/STM32_CAN does not seem to have a function to directly access pins.
2. Changed the data type for buf in CAN_data to uint8_t* from a uint8_t array.

canmanager.cpp:
1. Queue functions dependent on timers use millis() instead of Ticker.
3. Changed messageQueue functions to standard queue functions
