### PR TITLE
Add PID and ADC drivers

### DIFF
--- a/PID/pid.cpp
+++ b/PID/pid.cpp
@@ -1,0 +1,324 @@
+/**
+ * @author Aaron Berk
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2010 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ * 
+ * A PID controller is a widely used feedback controller commonly found in
+ * industry.
+ *
+ * This library is a port of Brett Beauregard's Arduino PID library:
+ *
+ *  http://www.arduino.cc/playground/Code/PIDLibrary
+ *
+ * The wikipedia article on PID controllers is a good place to start on
+ * understanding how they work:
+ *
+ *  http://en.wikipedia.org/wiki/PID_controller
+ *
+ * For a clear and elegant explanation of how to implement and tune a
+ * controller, the controlguru website by Douglas J. Cooper (who also happened
+ * to be Brett's controls professor) is an excellent reference:
+ *
+ *  http://www.controlguru.com/
+ */
+
+/**
+ * Includes
+ */
+#include "PID.h"
+
+PID::PID(float Kc, float tauI, float tauD, float interval) {
+
+    usingFeedForward = false;
+    inAuto           = false;
+
+    //Default the limits to the full range of I/O: 3.3V
+    //Make sure to set these to more appropriate limits for
+    //your application.
+    setInputLimits(0.0, 3.3);
+    setOutputLimits(0.0, 3.3);
+
+    tSample_ = interval;
+
+    setTunings(Kc, tauI, tauD);
+
+    setPoint_             = 0.0;
+    processVariable_      = 0.0;
+    prevProcessVariable_  = 0.0;
+    controllerOutput_     = 0.0;
+    prevControllerOutput_ = 0.0;
+
+    accError_ = 0.0;
+    bias_     = 0.0;
+    
+    realOutput_ = 0.0;
+
+}
+
+void PID::setInputLimits(float inMin, float inMax) {
+
+    //Make sure we haven't been given impossible values.
+    if (inMin >= inMax) {
+        return;
+    }
+
+    //Rescale the working variables to reflect the changes.
+    prevProcessVariable_ *= (inMax - inMin) / inSpan_;
+    accError_            *= (inMax - inMin) / inSpan_;
+
+    //Make sure the working variables are within the new limits.
+    if (prevProcessVariable_ > 1) {
+        prevProcessVariable_ = 1;
+    } else if (prevProcessVariable_ < 0) {
+        prevProcessVariable_ = 0;
+    }
+
+    inMin_  = inMin;
+    inMax_  = inMax;
+    inSpan_ = inMax - inMin;
+
+}
+
+void PID::setOutputLimits(float outMin, float outMax) {
+
+    //Make sure we haven't been given impossible values.
+    if (outMin >= outMax) {
+        return;
+    }
+
+    //Rescale the working variables to reflect the changes.
+    prevControllerOutput_ *= (outMax - outMin) / outSpan_;
+
+    //Make sure the working variables are within the new limits.
+    if (prevControllerOutput_ > 1) {
+        prevControllerOutput_ = 1;
+    } else if (prevControllerOutput_ < 0) {
+        prevControllerOutput_ = 0;
+    }
+
+    outMin_  = outMin;
+    outMax_  = outMax;
+    outSpan_ = outMax - outMin;
+
+}
+
+void PID::setTunings(float Kc, float tauI, float tauD) {
+
+    //Verify that the tunings make sense.
+    if (Kc == 0.0 || tauI < 0.0 || tauD < 0.0) {
+        return;
+    }
+
+    //Store raw values to hand back to user on request.
+    pParam_ = Kc;
+    iParam_ = tauI;
+    dParam_ = tauD;
+
+    float tempTauR;
+
+    if (tauI == 0.0) {
+        tempTauR = 0.0;
+    } else {
+        tempTauR = (1.0 / tauI) * tSample_;
+    }
+
+    //For "bumpless transfer" we need to rescale the accumulated error.
+    if (inAuto) {
+        if (tempTauR == 0.0) {
+            accError_ = 0.0;
+        } else {
+            accError_ *= (Kc_ * tauR_) / (Kc * tempTauR);
+        }
+    }
+
+    Kc_   = Kc;
+    tauR_ = tempTauR;
+    tauD_ = tauD / tSample_;
+
+}
+
+void PID::reset(void) {
+
+    float scaledBias = 0.0;
+
+    if (usingFeedForward) {
+        scaledBias = (bias_ - outMin_) / outSpan_;
+    } else {
+        scaledBias = (realOutput_ - outMin_) / outSpan_;
+    }
+
+    prevControllerOutput_ = scaledBias;
+    prevProcessVariable_  = (processVariable_ - inMin_) / inSpan_;
+
+    //Clear any error in the integral.
+    accError_ = 0;
+
+}
+
+void PID::setMode(int mode) {
+
+    //We were in manual, and we just got set to auto.
+    //Reset the controller internals.
+    if (mode != 0 && !inAuto) {
+        reset();
+    }
+
+    inAuto = (mode != 0);
+
+}
+
+void PID::setInterval(float interval) {
+
+    if (interval > 0) {
+        //Convert the time-based tunings to reflect this change.
+        tauR_     *= (interval / tSample_);
+        accError_ *= (tSample_ / interval);
+        tauD_     *= (interval / tSample_);
+        tSample_   = interval;
+    }
+
+}
+
+void PID::setSetPoint(float sp) {
+
+    setPoint_ = sp;
+
+}
+
+void PID::setProcessValue(float pv) {
+
+    processVariable_ = pv;
+
+}
+
+void PID::setBias(float bias){
+
+    bias_ = bias;
+    usingFeedForward = 1;
+
+}
+
+float PID::compute() {
+
+    //Pull in the input and setpoint, and scale them into percent span.
+    float scaledPV = (processVariable_ - inMin_) / inSpan_;
+
+    if (scaledPV > 1.0) {
+        scaledPV = 1.0;
+    } else if (scaledPV < 0.0) {
+        scaledPV = 0.0;
+    }
+
+    float scaledSP = (setPoint_ - inMin_) / inSpan_;
+    if (scaledSP > 1.0) {
+        scaledSP = 1;
+    } else if (scaledSP < 0.0) {
+        scaledSP = 0;
+    }
+
+    float error = scaledSP - scaledPV;
+
+    //Check and see if the output is pegged at a limit and only
+    //integrate if it is not. This is to prevent reset-windup.
+    if (!(prevControllerOutput_ >= 1 && error > 0) && !(prevControllerOutput_ <= 0 && error < 0)) {
+        accError_ += error;
+    }
+
+    //Compute the current slope of the input signal.
+    float dMeas = (scaledPV - prevProcessVariable_) / tSample_;
+
+    float scaledBias = 0.0;
+
+    if (usingFeedForward) {
+        scaledBias = (bias_ - outMin_) / outSpan_;
+    }
+
+    //Perform the PID calculation.
+    controllerOutput_ = scaledBias + Kc_ * (error + (tauR_ * accError_) - (tauD_ * dMeas));
+
+    //Make sure the computed output is within output constraints.
+    if (controllerOutput_ < 0.0) {
+        controllerOutput_ = 0.0;
+    } else if (controllerOutput_ > 1.0) {
+        controllerOutput_ = 1.0;
+    }
+
+    //Remember this output for the windup check next time.
+    prevControllerOutput_ = controllerOutput_;
+    //Remember the input for the derivative calculation next time.
+    prevProcessVariable_  = scaledPV;
+
+    //Scale the output from percent span back out to a real world number.
+    return ((controllerOutput_ * outSpan_) + outMin_);
+
+}
+
+float PID::getInMin() {
+
+    return inMin_;
+
+}
+
+float PID::getInMax() {
+
+    return inMax_;
+
+}
+
+float PID::getOutMin() {
+
+    return outMin_;
+
+}
+
+float PID::getOutMax() {
+
+    return outMax_;
+
+}
+
+float PID::getInterval() {
+
+    return tSample_;
+
+}
+
+float PID::getPParam() {
+
+    return pParam_;
+
+}
+
+float PID::getIParam() {
+
+    return iParam_;
+
+}
+
+float PID::getDParam() {
+
+    return dParam_;
+
+}

--- a/PID/pid.h
+++ b/PID/pid.h
@@ -1,0 +1,208 @@
+/**
+ * @author Aaron Berk
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2010 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ * 
+ * A PID controller is a widely used feedback controller commonly found in
+ * industry.
+ *
+ * This library is a port of Brett Beauregard's Arduino PID library:
+ *
+ *  http://www.arduino.cc/playground/Code/PIDLibrary
+ *
+ * The wikipedia article on PID controllers is a good place to start on
+ * understanding how they work:
+ *
+ *  http://en.wikipedia.org/wiki/PID_controller
+ *
+ * For a clear and elegant explanation of how to implement and tune a
+ * controller, the controlguru website by Douglas J. Cooper (who also happened
+ * to be Brett's controls professor) is an excellent reference:
+ *
+ *  http://www.controlguru.com/
+ */
+
+#ifndef PID_H
+#define PID_H
+
+/**
+ * Defines
+ */
+#define MANUAL_MODE 0
+#define AUTO_MODE   1
+
+/**
+ * Proportional-integral-derivative controller.
+ */
+class PID {
+
+public:
+
+    /**
+     * Constructor.
+     *
+     * Sets default limits [0-3.3V], calculates tuning parameters, and sets
+     * manual mode with no bias.
+     *
+     * @param Kc - Tuning parameter
+     * @param tauI - Tuning parameter
+     * @param tauD - Tuning parameter
+     * @param interval PID calculation performed every interval seconds.
+     */
+    PID(float Kc, float tauI, float tauD, float interval);
+
+    /**
+     * Scale from inputs to 0-100%.
+     *
+     * @param InMin The real world value corresponding to 0%.
+     * @param InMax The real world value corresponding to 100%.
+     */
+    void setInputLimits(float inMin , float inMax);
+
+    /**
+     * Scale from outputs to 0-100%.
+     *
+     * @param outMin The real world value corresponding to 0%.
+     * @param outMax The real world value corresponding to 100%.
+     */
+    void setOutputLimits(float outMin, float outMax);
+
+    /**
+     * Calculate PID constants.
+     *
+     * Allows parameters to be changed on the fly without ruining calculations.
+     *
+     * @param Kc - Tuning parameter
+     * @param tauI - Tuning parameter
+     * @param tauD - Tuning parameter
+     */
+    void setTunings(float Kc, float tauI, float tauD);
+
+    /**
+     * Reinitializes controller internals. Automatically
+     * called on a manual to auto transition.
+     */
+    void reset(void);
+    
+    /**
+     * Set PID to manual or auto mode.
+     *
+     * @param mode        0 -> Manual
+     *             Non-zero -> Auto
+     */
+    void setMode(int mode);
+    
+    /**
+     * Set how fast the PID loop is run.
+     *
+     * @param interval PID calculation peformed every interval seconds.
+     */
+    void setInterval(float interval);
+    
+    /**
+     * Set the set point.
+     *
+     * @param sp The set point as a real world value.
+     */
+    void setSetPoint(float sp);
+    
+    /**
+     * Set the process value.
+     *
+     * @param pv The process value as a real world value.
+     */
+    void setProcessValue(float pv);
+    
+    /**
+     * Set the bias.
+     *
+     * @param bias The bias for the controller output.
+     */
+    void setBias(float bias);
+
+    /**
+     * PID calculation.
+     *
+     * @return The controller output as a float between outMin and outMax.
+     */
+    float compute(void);
+
+    //Getters.
+    float getInMin();
+    float getInMax();
+    float getOutMin();
+    float getOutMax();
+    float getInterval();
+    float getPParam();
+    float getIParam();
+    float getDParam();
+
+private:
+
+    bool usingFeedForward;
+    bool inAuto;
+
+    //Actual tuning parameters used in PID calculation.
+    float Kc_;
+    float tauR_;
+    float tauD_;
+    
+    //Raw tuning parameters.
+    float pParam_;
+    float iParam_;
+    float dParam_;
+    
+    //The point we want to reach.
+    float setPoint_;         
+    //The thing we measure.
+    float processVariable_;  
+    float prevProcessVariable_;
+    //The output that affects the process variable.
+    float controllerOutput_; 
+    float prevControllerOutput_;
+
+    //We work in % for calculations so these will scale from
+    //real world values to 0-100% and back again.
+    float inMin_;
+    float inMax_;
+    float inSpan_;
+    float outMin_;
+    float outMax_;
+    float outSpan_;
+
+    //The accumulated error, i.e. integral.
+    float accError_;
+    //The controller output bias.
+    float bias_;
+
+    //The interval between samples.
+    float tSample_;          
+
+    //Controller output as a real world value.
+    volatile float realOutput_;
+
+};
+
+#endif /* PID_H */

--- a/adc/adc.cpp
+++ b/adc/adc.cpp
@@ -1,0 +1,83 @@
+#include "adc.h"
+
+ADC_HandleTypeDef AdcHandle;
+ADC_ChannelConfTypeDef sConfig;
+
+/* This function must be called in setup(). 
+ * @param instance ADC#, where # is the handle number. 
+ */
+void initADC(ADC_TypeDef* instance) {
+    AdcHandle.Instance = instance;
+
+    //deinitialize ADC
+    if (HAL_ADC_DeInit(&AdcHandle) != HAL_OK) {
+        Error_Handler();
+    }
+
+    AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV1;          /* Asynchronous clock mode, input ADC clock not divided */
+    AdcHandle.Init.Resolution            = ADC_RESOLUTION_12B;            /* 12-bit resolution for converted data */
+    AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;           /* Right-alignment for converted data */
+    AdcHandle.Init.ScanConvMode          = DISABLE;                       /* Sequencer disabled (ADC conversion on only 1 channel: channel set on rank 1) */
+    AdcHandle.Init.EOCSelection          = ADC_EOC_SINGLE_CONV;           /* EOC flag picked-up to indicate conversion end */
+    AdcHandle.Init.LowPowerAutoWait      = DISABLE;                       /* Auto-delayed conversion feature disabled */
+    AdcHandle.Init.ContinuousConvMode    = DISABLE;                       /* Continuous mode disabled to have only 1 conversion at each conversion trig */
+    AdcHandle.Init.NbrOfConversion       = 1;                             /* Parameter discarded because sequencer is disabled */
+    AdcHandle.Init.DiscontinuousConvMode = DISABLE;                       /* Parameter discarded because sequencer is disabled */
+    AdcHandle.Init.NbrOfDiscConversion   = 1;                             /* Parameter discarded because sequencer is disabled */
+    AdcHandle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;            /* Software start to trig the 1st conversion manually, without external event */
+    AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE; /* Parameter discarded because software trigger chosen */
+    AdcHandle.Init.DMAContinuousRequests = DISABLE;                       /* DMA one-shot mode selected (not applied to this example) */
+    AdcHandle.Init.Overrun               = ADC_OVR_DATA_OVERWRITTEN;      /* DR register is overwritten with the last conversion result in case of overrun */
+    AdcHandle.Init.OversamplingMode      = DISABLE;                       /* No oversampling */
+
+    // initialize ADC
+    if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+        Error_Handler();
+    }
+
+    /* Run the ADC calibration in single-ended mode */
+    if (HAL_ADCEx_Calibration_Start(&AdcHandle, ADC_SINGLE_ENDED) != HAL_OK) {
+        Error_Handler();
+    }
+
+    /*##-2- Configure ADC regular channel ######################################*/
+    sConfig.Rank         = ADC_REGULAR_RANK_1;          /* Rank of sampled channel number ADCx_CHANNEL */
+    sConfig.SamplingTime = ADC_SAMPLETIME_6CYCLES_5;    /* Sampling time (number of clock cycles unit) */
+    sConfig.SingleDiff   = ADC_SINGLE_ENDED;            /* Single-ended input channel */
+    sConfig.OffsetNumber = ADC_OFFSET_NONE;             /* No offset subtraction */ 
+    sConfig.Offset = 0;                                 /* Parameter discarded because offset correction is disabled */
+
+}
+
+
+
+/* Reads the analog value of the specified pin. 
+ * @param channel ADC_CHANNEL_#, where # is the number of the channel
+ * @return ADC voltage represented as a float in the range [0.0, 1.0]
+ */
+float readADC(uint32_t channel) {
+     sConfig.Channel = channel;                /* Sampled channel number */
+    // configure channel
+    if (HAL_ADC_ConfigChannel(&AdcHandle, &sConfig) != HAL_OK) {
+        Error_Handler();
+    }
+
+     /*##-3- Start the conversion process #######################################*/
+    if (HAL_ADC_Start(&AdcHandle) != HAL_OK) {
+        Error_Handler();
+    }
+
+    /*##-4- Wait for the end of conversion #####################################*/
+    /*  For simplicity reasons, this example is just waiting till the end of the
+        conversion, but application may perform other tasks while conversion
+        operation is ongoing. */
+    if (HAL_ADC_PollForConversion(&AdcHandle, 10) != HAL_OK) {
+        Error_Handler();
+    }
+    else {
+        /* ADC conversion completed */
+        /*##-5- Get the converted value of regular channel  ########################*/
+        return (float)HAL_ADC_GetValue(&AdcHandle) / ADC_MAX_VALUE;
+    }
+    
+} 

--- a/adc/adc.h
+++ b/adc/adc.h
@@ -1,0 +1,10 @@
+#ifndef __ADC_H__
+#define __ADC_H__
+#include <Arduino.h>
+
+#define ADC_MAX_VALUE 4096 // because we use 12 bit ADC
+
+void initADC(ADC_TypeDef* instance);
+float readADC(uint32_t channel);
+
+#endif

--- a/ina281/ina281.cpp
+++ b/ina281/ina281.cpp
@@ -3,9 +3,8 @@
 /*
     Initialize I2C bus member and parameters
 */
-INA281Driver::INA281Driver(int analogPin, float resistance, float scaleFactor)
-{
-    this->analogPin = analogPin;
+INA281Driver::INA281Driver(uint32_t channel, float resistance, float scaleFactor) {
+    this->channel = channel;
     this->resistance = resistance;
     this->scaleFactor = scaleFactor; 
 }
@@ -13,14 +12,8 @@ INA281Driver::INA281Driver(int analogPin, float resistance, float scaleFactor)
 /*
     Retrieve new current reading
 */
-float INA281Driver::readCurrent()
-{
-    int valueRead;
-
-    valueRead = analogRead(this->analogPin);
-    
-
-    float measuredVoltage = (float)valueRead * 3.3/1024.0;
+float INA281Driver::readCurrent() {
+    float measuredVoltage = readADC(this->channel) * 3.3;
 
     // voltage = measuredVoltage / scaleFactor
     // current = voltage / resistance
@@ -32,13 +25,8 @@ float INA281Driver::readCurrent()
 /*
     Retrieve new voltage reading
 */
-float INA281Driver::readVoltage()
-{
-    int valueRead = analogRead(this->analogPin);
-
-    float measuredVoltage = (float)valueRead * 3.3/1024.0;
-
+float INA281Driver::readVoltage() {
+    float measuredVoltage = readADC(this->channel) * 3.3;
     float voltage = measuredVoltage / scaleFactor;
-
     return voltage;
 }

--- a/ina281/ina281.h
+++ b/ina281/ina281.h
@@ -1,7 +1,7 @@
 #ifndef _INA281_H_
 #define _INA281_H_
 
-#include <Wire.h>
+#include "adc.h"
 
 /*
     A class which represents an instance of an INA281 Driver for measuring current across a
@@ -11,7 +11,7 @@
 */
 class INA281Driver {
  private:
-    int analogPin;
+    uint32_t channel;
     float resistance;
     float scaleFactor;
 
@@ -21,13 +21,13 @@ class INA281Driver {
         Creates a new INA281 Driver
 
         Constructor expects 2 arguments:
-        analogPin - name of analog pin the INA is wired to
+        channel - channel of the analog pin the INA is wired to
         resistance - resistance of the shunt resistor associated with the INA
 
         Optional argument:
         scaleFactor - the factor by which to divide the pin reading to get the correct voltage
     */
-    INA281Driver(int analogPin, float resistance, float scaleFactor = 20);
+    INA281Driver(uint32_t channel, float resistance, float scaleFactor = 20);
 
     /*
         Retrieves the current current reading

--- a/thermistor/thermistor.cpp
+++ b/thermistor/thermistor.cpp
@@ -3,7 +3,7 @@
 /*
     Initialize all parameters and pin
 */
-Thermistor::Thermistor(const Thermistor_Constants constants, int therm_channel, float R, float vcc) : thermChannel(therm_channel) {
+Thermistor::Thermistor(const Thermistor_Constants constants, uint32_t therm_channel, float R, float vcc) : thermChannel(therm_channel) {
     this->mult_const = constants.mult_const;
     this->add_const = constants.add_const;
     this->vcc = vcc;
@@ -14,8 +14,7 @@ Thermistor::Thermistor(const Thermistor_Constants constants, int therm_channel, 
     Retrive new temperature reading
 */
 float Thermistor::get_temperature() {
-    int valueRead = readADC(this->thermChannel);
-    float therm_voltage = (float)valueRead * 3.3/1024.0;
+    float therm_voltage = readADC(this->thermChannel) * 3.3;
     float R_Therm = R / (vcc / therm_voltage - 1);
 
     return mult_const * std::log(R_Therm) + add_const;

--- a/thermistor/thermistor.cpp
+++ b/thermistor/thermistor.cpp
@@ -1,10 +1,9 @@
 #include "thermistor.h"
-#include <math.h>
 
 /*
     Initialize all parameters and pin
 */
-Thermistor::Thermistor(const Thermistor_Constants constants, int therm_pin, float R, float vcc) : thermVoltPin(therm_pin) {
+Thermistor::Thermistor(const Thermistor_Constants constants, int therm_channel, float R, float vcc) : thermChannel(therm_channel) {
     this->mult_const = constants.mult_const;
     this->add_const = constants.add_const;
     this->vcc = vcc;
@@ -15,7 +14,7 @@ Thermistor::Thermistor(const Thermistor_Constants constants, int therm_pin, floa
     Retrive new temperature reading
 */
 float Thermistor::get_temperature() {
-    int valueRead = analogRead(this->thermVoltPin);
+    int valueRead = readADC(this->thermChannel);
     float therm_voltage = (float)valueRead * 3.3/1024.0;
     float R_Therm = R / (vcc / therm_voltage - 1);
 

--- a/thermistor/thermistor.h
+++ b/thermistor/thermistor.h
@@ -38,7 +38,7 @@ class Thermistor{
     float add_const;
     float vcc;
     float R;
-    int thermChannel;
+    uint32_t thermChannel;
 
     public:
     /*
@@ -50,7 +50,7 @@ class Thermistor{
         R: Resistance of resistor in series with thermistor
         vcc: Total voltage across R and thermistor
     */
-    Thermistor(const Thermistor_Constants constants, int therm_channel, float R = 4700, float vcc = 3.3);
+    Thermistor(const Thermistor_Constants constants, uint32_t therm_channel, float R = 4700, float vcc = 3.3);
 
     /*
         Retrives current thermistor reading

--- a/thermistor/thermistor.h
+++ b/thermistor/thermistor.h
@@ -2,6 +2,8 @@
 #define __THERMISTOR_H__
 
 #include <Wire.h>
+#include <math.h>
+#include "adc.h"
 
 /*
     Thermistor voltage reading is converted to temperature in a two step process
@@ -36,7 +38,7 @@ class Thermistor{
     float add_const;
     float vcc;
     float R;
-    int thermVoltPin;
+    int thermChannel;
 
     public:
     /*
@@ -48,7 +50,7 @@ class Thermistor{
         R: Resistance of resistor in series with thermistor
         vcc: Total voltage across R and thermistor
     */
-    Thermistor(const Thermistor_Constants constants, int therm_pin, float R = 4700, float vcc = 3.3);
+    Thermistor(const Thermistor_Constants constants, int therm_channel, float R = 4700, float vcc = 3.3);
 
     /*
         Retrives current thermistor reading


### PR DESCRIPTION
The PID library is copied from [David Salmon's fork](https://os.mbed.com/users/david_s95/code/PID/#7924828bb40e6bb89a54d4b36109b4c27c3007a7) of the Mbed PID library by Aaron Berk. This PID library isn't unique at all to Mbed, so we can use it in PlatformIO no problem. 

The ADC library was written by me, @bquan0. See the confluence documentation for more details and the sources I used to make it. 